### PR TITLE
Add content in editor if as_html value is not empty

### DIFF
--- a/lib/wysiwyg/wysiwyg.coffee
+++ b/lib/wysiwyg/wysiwyg.coffee
@@ -30,6 +30,11 @@ Wysiwyg = Component.extend WithConfigMixin,
         @set 'toolbars', ArrayProxy.create({content: []})
     ).on 'init'
 
+    initEditorContent: (->
+        if @get 'editor'
+            Ember.run.once @, (-> @get('editor').$().html(@get 'as_html'))
+    ).observes 'editor'
+
     ###*
     # Add the given `Toolbar` instance.
     ###


### PR DESCRIPTION
Hi.

If as_html property contain any value, editor doesn't show this value.