### PR TITLE
npm install should use --save-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project aims to be the successor of our Bootstrap for Ember project as all 
 # Installation & Docs
 
 With ember-cli:
-`npm install --save ember-cli-components`
+`npm install --save-dev ember-cli-components`
 
 For more info please read the [Getting Started Page](http://indexiatech.github.io/ember-components/#/getstarted)
 


### PR DESCRIPTION
The [Getting Starting](http://indexiatech.github.io/ember-components/#/getstarted) guide uses the correct from, `--save-dev` (since this addons themselves are part of the build/dev process). Minor technicality..just being consistent.
