### PR TITLE
Include ARIA attributes and roles for better accessibility within modals

### DIFF
--- a/lib/modal/modal-confirm-tmpl.hbs
+++ b/lib/modal/modal-confirm-tmpl.hbs
@@ -1,6 +1,6 @@
-{{#em-modal id=confirm-id configName=configName model-id=model-id open-if=open-if close-if=close-if}}
+{{#em-modal id=confirm-id configName=configName model-id=model-id tabindex="-1" role="dialog" aria-hidden="true" open-if=open-if close-if=close-if}}
     {{#em-modal-title}}
-        {{#em-modal-toggler class="close"}}<span aria-hidden="true">&times;</span><span class="sr-only">Close</span>{{/em-modal-toggler}}
+        {{#em-modal-toggler class="close" aria-label="Close"}}<span aria-hidden="true">&times;</span><span class="sr-only">Close</span>{{/em-modal-toggler}}
         <h4 class="modal-title">{{title}}</h4>
     {{/em-modal-title}}
     {{#em-modal-body}}


### PR DESCRIPTION
Include ARIA attributes and roles for better accessibility per the examples found at http://getbootstrap.com/javascript/#modals-examples
